### PR TITLE
Handling missing data using trim method

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ exports.handler = function (event, context) {
     function parseEvent(logEvent, logGroupName, logStreamName) {
         return {
             // remove '\n' character at the end of the event
-            message: logEvent.message.substring(0, logEvent.message.length - 1),
+            message: logEvent.message.trim(),
             logGroupName: logGroupName,
             logStreamName: logStreamName,
             timestamp: new Date(logEvent.timestamp).toISOString()


### PR DESCRIPTION
@mchaudhary @mostlyjason, This PR is to resolve the issue with javascript lambda function which removes the data from the end of the log message. 

Replacing with `trim()` method resolves the issue. Please review and merge the PR.

Thank you!